### PR TITLE
chore(release): bump version 0.1.0 → 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-mpm-agents"
-version = "0.1.0"
+version = "0.1.1"
 description = "Claude MPM Agents with DeepEval testing"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release `v0.1.1` consolidating fixes and improvements merged since `v0.1.0`.

## Changes Included

- **feat(react-engineer)**: Add advanced React patterns from production analysis (SWR hooks, memoized context, debounced search, event propagation, state machines, pure helpers)
- **fix(version-control)**: Add explicit `NEVER merge PR directly` guardrail (closes #12)
- **fix(ci)**: Pin ruff to v0.14.14 in pre-commit to match CI, reformat test files
- **fix(agents)**: Add missing `agent_id`/`agent_type` to nestjs-engineer and real-user agents
- **fix(tests)**: Fix `Mock(name=...)` bug in browser tool tests; skip DeepEval tests when `OPENAI_API_KEY` not set
- **fix(agents)**: Fix invalid skill references in aws-ops (full path → short names) and react-engineer (remove non-existent `swr` skill)

## Test plan

- [x] All CI checks pass (Lint Tests + Run Agent Tests)
- [x] Version bump only changes `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)