### PR TITLE
feat: add source:external provenance field to all agents

### DIFF
--- a/agents/claude-mpm/mpm-agent-manager.md
+++ b/agents/claude-mpm/mpm-agent-manager.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: mpm-agent-manager
 agent_type: system
+source: external
 resource_tier: standard
 tags:
 - agent-management

--- a/agents/claude-mpm/mpm-skills-manager.md
+++ b/agents/claude-mpm/mpm-skills-manager.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: mpm-skills-manager
 agent_type: claude-mpm
+source: external
 resource_tier: standard
 tags:
 - skill-management

--- a/agents/documentation/documentation.md
+++ b/agents/documentation/documentation.md
@@ -5,6 +5,7 @@ version: 3.4.2
 schema_version: 1.3.0
 agent_id: documentation
 agent_type: documentation
+source: external
 resource_tier: lightweight
 tags:
 - documentation

--- a/agents/documentation/ticketing.md
+++ b/agents/documentation/ticketing.md
@@ -5,6 +5,7 @@ version: 2.7.0
 schema_version: 1.3.0
 agent_id: ticketing
 agent_type: documentation
+source: external
 resource_tier: lightweight
 tags:
 - ticketing

--- a/agents/engineer/backend/golang-engineer.md
+++ b/agents/engineer/backend/golang-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: golang-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - golang

--- a/agents/engineer/backend/java-engineer.md
+++ b/agents/engineer/backend/java-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: java-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - java

--- a/agents/engineer/backend/javascript-engineer.md
+++ b/agents/engineer/backend/javascript-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: javascript-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - javascript

--- a/agents/engineer/backend/nestjs-engineer.md
+++ b/agents/engineer/backend/nestjs-engineer.md
@@ -13,6 +13,7 @@ This agent is well-suited for JWT authentication because it specializes in @nest
 model: sonnet
 agent_id: nestjs-engineer
 agent_type: engineer
+source: external
 version: "1.0.0"
 schema_version: 1.3.0
 tags:

--- a/agents/engineer/backend/phoenix-engineer.md
+++ b/agents/engineer/backend/phoenix-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: phoenix-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - elixir

--- a/agents/engineer/backend/php-engineer.md
+++ b/agents/engineer/backend/php-engineer.md
@@ -5,6 +5,7 @@ version: 2.1.0
 schema_version: 1.3.0
 agent_id: php-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - php

--- a/agents/engineer/backend/python-engineer.md
+++ b/agents/engineer/backend/python-engineer.md
@@ -5,6 +5,7 @@ version: 2.3.0
 schema_version: 1.3.0
 agent_id: python-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - python

--- a/agents/engineer/backend/ruby-engineer.md
+++ b/agents/engineer/backend/ruby-engineer.md
@@ -5,6 +5,7 @@ version: 2.0.0
 schema_version: 1.3.0
 agent_id: ruby-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - ruby

--- a/agents/engineer/backend/rust-engineer.md
+++ b/agents/engineer/backend/rust-engineer.md
@@ -5,6 +5,7 @@ version: 2.0.0
 schema_version: 1.3.0
 agent_id: rust-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - rust

--- a/agents/engineer/backend/visual-basic-engineer.md
+++ b/agents/engineer/backend/visual-basic-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: visual-basic-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - visual-basic

--- a/agents/engineer/core/engineer.md
+++ b/agents/engineer/core/engineer.md
@@ -5,6 +5,7 @@ version: 3.9.1
 schema_version: 1.3.0
 agent_id: engineer
 agent_type: engineer
+source: external
 resource_tier: intensive
 tags:
 - engineering

--- a/agents/engineer/data/data-engineer.md
+++ b/agents/engineer/data/data-engineer.md
@@ -5,6 +5,7 @@ version: 2.5.1
 schema_version: 1.3.0
 agent_id: data-engineer
 agent_type: engineer
+source: external
 resource_tier: intensive
 tags:
 - data

--- a/agents/engineer/data/data-scientist.md
+++ b/agents/engineer/data/data-scientist.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: data-scientist
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - data-science

--- a/agents/engineer/data/typescript-engineer.md
+++ b/agents/engineer/data/typescript-engineer.md
@@ -5,6 +5,7 @@ version: 2.0.0
 schema_version: 1.3.0
 agent_id: typescript-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - typescript

--- a/agents/engineer/frontend/nextjs-engineer.md
+++ b/agents/engineer/frontend/nextjs-engineer.md
@@ -5,6 +5,7 @@ version: 2.1.0
 schema_version: 1.3.0
 agent_id: nextjs-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - nextjs

--- a/agents/engineer/frontend/react-engineer.md
+++ b/agents/engineer/frontend/react-engineer.md
@@ -5,6 +5,7 @@ version: 1.3.0
 schema_version: 1.3.0
 agent_id: react-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - react

--- a/agents/engineer/frontend/svelte-engineer.md
+++ b/agents/engineer/frontend/svelte-engineer.md
@@ -5,6 +5,7 @@ version: 1.1.0
 schema_version: 1.3.0
 agent_id: svelte-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - svelte

--- a/agents/engineer/frontend/web-ui-engineer.md
+++ b/agents/engineer/frontend/web-ui-engineer.md
@@ -5,6 +5,7 @@ version: 1.4.2
 schema_version: 1.3.0
 agent_id: web-ui-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - web-ui

--- a/agents/engineer/mobile/dart-engineer.md
+++ b/agents/engineer/mobile/dart-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: dart-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - dart

--- a/agents/engineer/mobile/tauri-engineer.md
+++ b/agents/engineer/mobile/tauri-engineer.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: tauri-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - tauri

--- a/agents/engineer/specialized/imagemagick.md
+++ b/agents/engineer/specialized/imagemagick.md
@@ -5,6 +5,7 @@ version: 1.0.2
 schema_version: 1.3.0
 agent_id: imagemagick
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - imagemagick

--- a/agents/engineer/specialized/prompt-engineer.md
+++ b/agents/engineer/specialized/prompt-engineer.md
@@ -5,6 +5,7 @@ version: 3.0.0
 schema_version: 1.3.0
 agent_id: prompt-engineer
 agent_type: engineer
+source: external
 resource_tier: standard
 tags:
 - prompt-engineering

--- a/agents/engineer/specialized/refactoring-engineer.md
+++ b/agents/engineer/specialized/refactoring-engineer.md
@@ -5,6 +5,7 @@ version: 1.1.3
 schema_version: 1.3.0
 agent_id: refactoring-engineer
 agent_type: engineer
+source: external
 resource_tier: intensive
 tags:
 - refactoring

--- a/agents/ops/agentic-coder-optimizer.md
+++ b/agents/ops/agentic-coder-optimizer.md
@@ -5,6 +5,7 @@ version: 0.0.9
 schema_version: 1.3.0
 agent_id: agentic-coder-optimizer
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - optimization

--- a/agents/ops/core/ops.md
+++ b/agents/ops/core/ops.md
@@ -5,6 +5,7 @@ version: 2.2.4
 schema_version: 1.3.0
 agent_id: ops
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - ops

--- a/agents/ops/platform/aws-ops.md
+++ b/agents/ops/platform/aws-ops.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: aws-ops
 agent_type: ops
+source: external
 model: sonnet
 resource_tier: standard
 tags:

--- a/agents/ops/platform/clerk-ops.md
+++ b/agents/ops/platform/clerk-ops.md
@@ -5,6 +5,7 @@ version: 1.1.1
 schema_version: 1.3.0
 agent_id: clerk-ops
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - clerk

--- a/agents/ops/platform/digitalocean-ops.md
+++ b/agents/ops/platform/digitalocean-ops.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: digitalocean-ops
 agent_type: ops
+source: external
 model: sonnet
 resource_tier: standard
 tags:

--- a/agents/ops/platform/gcp-ops.md
+++ b/agents/ops/platform/gcp-ops.md
@@ -5,6 +5,7 @@ version: 1.0.2
 schema_version: 1.3.0
 agent_id: gcp-ops
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - gcp

--- a/agents/ops/platform/local-ops.md
+++ b/agents/ops/platform/local-ops.md
@@ -5,6 +5,7 @@ version: 2.0.1
 schema_version: 1.3.0
 agent_id: local-ops
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - deployment

--- a/agents/ops/platform/vercel-ops.md
+++ b/agents/ops/platform/vercel-ops.md
@@ -5,6 +5,7 @@ version: 2.0.1
 schema_version: 1.3.0
 agent_id: vercel-ops
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - vercel

--- a/agents/ops/project-organizer.md
+++ b/agents/ops/project-organizer.md
@@ -5,6 +5,7 @@ version: 1.2.0
 schema_version: 1.3.0
 agent_id: project-organizer
 agent_type: ops
+source: external
 resource_tier: standard
 tags:
 - organization

--- a/agents/ops/tooling/tmux.md
+++ b/agents/ops/tooling/tmux.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: tmux
 agent_type: ops
+source: external
 resource_tier: medium
 tags:
 - tmux

--- a/agents/ops/tooling/version-control.md
+++ b/agents/ops/tooling/version-control.md
@@ -5,6 +5,7 @@ version: 2.3.2
 schema_version: 1.3.0
 agent_id: version-control
 agent_type: ops
+source: external
 resource_tier: lightweight
 tags:
 - git

--- a/agents/qa/api-qa.md
+++ b/agents/qa/api-qa.md
@@ -5,6 +5,7 @@ version: 1.2.2
 schema_version: 1.3.0
 agent_id: api-qa
 agent_type: qa
+source: external
 resource_tier: standard
 tags:
 - api_qa

--- a/agents/qa/code-critic.md
+++ b/agents/qa/code-critic.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: code-critic
 agent_type: qa
+source: external
 resource_tier: standard
 tags: [code-review, critic, quality-gate, verdict, code-production-pipeline]
 category: quality

--- a/agents/qa/qa.md
+++ b/agents/qa/qa.md
@@ -5,6 +5,7 @@ version: 3.5.3
 schema_version: 1.3.0
 agent_id: qa
 agent_type: qa
+source: external
 resource_tier: standard
 tags:
 - qa

--- a/agents/qa/real-user.md
+++ b/agents/qa/real-user.md
@@ -3,6 +3,7 @@ name: Real User
 description: "Persona-based behavioral testing agent that simulates realistic user interactions. Configures user personas with varying tech savviness, patience, and device preferences to test applications from authentic user perspectives."
 agent_id: real-user
 agent_type: qa
+source: external
 version: "1.0.0"
 schema_version: 1.3.0
 skills:

--- a/agents/qa/web-qa.md
+++ b/agents/qa/web-qa.md
@@ -5,6 +5,7 @@ version: 3.1.0
 schema_version: 1.3.0
 agent_id: web-qa
 agent_type: qa
+source: external
 resource_tier: standard
 tags:
 - web_qa

--- a/agents/security/security.md
+++ b/agents/security/security.md
@@ -5,6 +5,7 @@ version: 2.5.0
 schema_version: 1.3.0
 agent_id: security
 agent_type: security
+source: external
 resource_tier: standard
 tags:
 - security

--- a/agents/universal/code-analyzer.md
+++ b/agents/universal/code-analyzer.md
@@ -5,6 +5,7 @@ version: 2.6.2
 schema_version: 1.3.0
 agent_id: code-analyzer
 agent_type: research
+source: external
 resource_tier: standard
 tags:
 - code-analysis

--- a/agents/universal/content.md
+++ b/agents/universal/content.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: content
 agent_type: universal
+source: external
 resource_tier: standard
 tags:
 - content-optimization

--- a/agents/universal/memory-manager.md
+++ b/agents/universal/memory-manager.md
@@ -5,6 +5,7 @@ version: 1.2.0
 schema_version: 1.3.0
 agent_id: memory-manager
 agent_type: universal
+source: external
 resource_tier: lightweight
 tags:
 - memory

--- a/agents/universal/product-owner.md
+++ b/agents/universal/product-owner.md
@@ -5,6 +5,7 @@ version: 1.0.0
 schema_version: 1.3.0
 agent_id: product-owner
 agent_type: universal
+source: external
 resource_tier: standard
 tags:
 - product-management

--- a/agents/universal/research.md
+++ b/agents/universal/research.md
@@ -5,6 +5,7 @@ version: 5.0.0
 schema_version: 1.3.0
 agent_id: research
 agent_type: research
+source: external
 resource_tier: high
 tags:
 - research


### PR DESCRIPTION
## Summary

- Introduces the `source` frontmatter field (enum `bundled | external`) to all agent definition files in this repository to mark agent ownership.
- All 49 agents in this repo are marked `source: external` — they are synced/deployed into projects by the `claude-mpm` CLI, not bundled inside the package itself.
- The 5 `BASE-AGENT.md` files (which contain no YAML frontmatter, only markdown instruction bodies) are intentionally excluded.
- The complementary `source: bundled` marking for agents that ship inside the `claude-mpm` package, plus schema/validator/display support for the new field, will land in a separate PR against the `claude-mpm` repo.

## Field placement

`source: external` is inserted immediately after `agent_type` in each file, co-locating provenance with other top-level identity keys. Existing key order and formatting are otherwise unchanged — every file has exactly one-line diff (`+source: external`).

## Validation

- `tests/test_agent_registry.py` and `tests/test_compiled_agents.py` (52 tests) all pass.
- `build-agent.py --validate` reports only pre-existing skill-reference warnings unrelated to this change; it does not reject unknown frontmatter keys.
- No test enforces an allowlist of frontmatter keys, so the new field is accepted silently by all parsers.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)