### PR TITLE
fix(agents): standardize AI-attribution footer to canonical MPM format

### DIFF
--- a/agents/claude-mpm/mpm-agent-manager.md
+++ b/agents/claude-mpm/mpm-agent-manager.md
@@ -1,7 +1,7 @@
 ---
 name: MPM Agent Manager
 description: Manages agent lifecycle including discovery, configuration, deployment, and PR-based improvements to the agent repository
-version: 1.0.0
+version: 1.0.1
 schema_version: 1.3.0
 agent_id: mpm-agent-manager
 agent_type: system
@@ -46,6 +46,13 @@ skills:
 - internal-comms
 - mcp-builder
 - test-driven-development
+template_changelog:
+- version: 1.0.1
+  date: '2026-06-09'
+  description: Standardize AI-attribution footer to canonical MPM format with repo link
+- version: 1.0.0
+  date: '2025-11-01'
+  description: Initial MPM Agent Manager release
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
@@ -395,7 +402,7 @@ Closes #{issue_number}
 - [ ] Testing notes comprehensive
 
 ---
-🤖 Generated with Claude MPM Agent Manager
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 Co-Authored-By: mpm-agent-manager <noreply@anthropic.com>
 ```
 

--- a/agents/documentation/ticketing.md
+++ b/agents/documentation/ticketing.md
@@ -1,7 +1,7 @@
 ---
 name: Ticketing
 description: Intelligent ticket management using mcp-ticketer MCP server (primary) with aitrackdown CLI fallback
-version: 2.7.0
+version: 2.8.0
 schema_version: 1.3.0
 agent_id: ticketing
 agent_type: documentation
@@ -49,6 +49,10 @@ skills:
 - verification-before-completion
 - internal-comms
 - test-driven-development
+template_changelog:
+- version: 2.8.0
+  date: '2026-06-09'
+  description: Add explicit directive for canonical MPM AI-attribution footer on GitHub issues and PRs
 knowledge:
   domain_expertise:
   - Agile project management
@@ -109,6 +113,48 @@ skills:
 # Ticketing Agent
 
 Intelligent ticket management with MCP-first architecture and script-based fallbacks.
+
+## AI-Attribution Footer Standard
+
+When creating GitHub issues or PRs, you MUST ALWAYS append the canonical MPM footer to issue bodies, PR descriptions, and commit messages. This identifies work as AI-generated and provides proper attribution.
+
+**CANONICAL FOOTER (use verbatim)**:
+```
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
+
+**IMPORTANT RULES**:
+- ✅ **ALWAYS** include the canonical footer in GitHub issues
+- ✅ **ALWAYS** include the canonical footer in PR descriptions
+- ✅ **ALWAYS** include the canonical footer in commit messages (in addition to `Co-Authored-By` trailer)
+- ❌ **NEVER** use the Claude Code footer: "🤖 Generated with [Claude Code]"
+- ❌ **NEVER** use custom footers or variations
+- ❌ **NEVER** omit the footer entirely
+
+**Commit Message Example**:
+```
+feat(auth): implement OAuth2 token refresh
+
+- Add token refresh endpoint
+- Update session management logic
+- Add comprehensive test coverage
+
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+
+Co-Authored-By: Claude MPM <noreply@anthropic.com>
+```
+
+**GitHub Issue Body Example**:
+```markdown
+## Problem
+Users cannot refresh expired OAuth2 tokens.
+
+## Solution
+Add token refresh endpoint with automatic retry logic.
+
+---
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
 
 ## Tag Preservation Protocol
 

--- a/agents/ops/core/ops.md
+++ b/agents/ops/core/ops.md
@@ -1,7 +1,7 @@
 ---
 name: Ops
 description: Infrastructure automation with IaC validation and container security
-version: 2.2.4
+version: 2.2.5
 schema_version: 1.3.0
 agent_id: ops
 agent_type: ops
@@ -54,6 +54,9 @@ skills:
 - test-driven-development
 template_version: 2.2.0
 template_changelog:
+- version: 2.2.5
+  date: '2026-06-09'
+  description: Standardize AI-attribution footer to canonical MPM format with repo link
 - version: 2.2.0
   date: '2025-08-29'
   description: Added comprehensive git commit authority with mandatory security verification
@@ -323,7 +326,7 @@ find . -type f -size +1000k -not -path "./.git/*" -not -path "./node_modules/*"
    - Detail 1
    - Detail 2
    
-    Generated with [Claude Code](https://claude.ai/code)
+   🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
    
    Co-Authored-By: Claude <noreply@anthropic.com>"
    ```

--- a/templates/base/base-engineer.md
+++ b/templates/base/base-engineer.md
@@ -236,7 +236,7 @@ type(scope): short description
 - Detailed change 1
 - Detailed change 2
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```


### PR DESCRIPTION
## Summary

Standardizes AI-attribution footers across all agent templates to the canonical MPM format with proper GitHub repository link and dual-glyph branding.

**Canonical Footer**: `🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)`

## Changes

Four agents updated with standardized footer:

1. **agents/claude-mpm/mpm-agent-manager.md** (v1.0.0 → v1.0.1)
   - Updated footer in PR template example from generic to canonical MPM format
   - Added template_changelog entry

2. **agents/ops/core/ops.md** (v2.2.4 → v2.2.5)
   - Replaced Claude Code footer with canonical MPM format in commit message example
   - Added template_changelog entry

3. **templates/base/base-engineer.md** (unchanged version)
   - Replaced Claude Code footer with canonical MPM format in commit message example

4. **agents/documentation/ticketing.md** (v2.7.0 → v2.8.0)
   - Added new 'AI-Attribution Footer Standard' section with comprehensive guidance
   - Documents canonical footer requirement for issues, PRs, and commit messages
   - Explicitly prohibits Claude Code footer usage
   - Includes examples for both commit messages and GitHub issue bodies
   - Added template_changelog entry

## Rationale

This work aligns with MPM branding standards and ensures all AI-generated artifacts carry proper attribution with repository linkage. References bobmatnyc/claude-mpm#708 and #710 for context.

## Testing

- [x] Verified YAML frontmatter syntax on all modified files
- [x] Confirmed all footers match the canonical format exactly
- [x] Version bumps follow semantic versioning (PATCH for fixes, MINOR for new guidance)
- [x] Template_changelog entries added where applicable
- [x] No breaking changes to agent functionality

---
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)