### PR TITLE
fix(agents): align commit trailer to "Co-Authored-By: Claude MPM"

### DIFF
--- a/agents/claude-mpm/mpm-agent-manager.md
+++ b/agents/claude-mpm/mpm-agent-manager.md
@@ -403,7 +403,7 @@ Closes #{issue_number}
 
 ---
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
-Co-Authored-By: mpm-agent-manager <noreply@anthropic.com>
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 ```
 
 **3. Create PR via GitHub CLI**

--- a/agents/documentation/ticketing.md
+++ b/agents/documentation/ticketing.md
@@ -141,7 +141,7 @@ feat(auth): implement OAuth2 token refresh
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude MPM <noreply@anthropic.com>
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 ```
 
 **GitHub Issue Body Example**:

--- a/agents/ops/core/ops.md
+++ b/agents/ops/core/ops.md
@@ -1,7 +1,7 @@
 ---
 name: Ops
 description: Infrastructure automation with IaC validation and container security
-version: 2.2.5
+version: 2.2.6
 schema_version: 1.3.0
 agent_id: ops
 agent_type: ops
@@ -52,8 +52,11 @@ skills:
 - internal-comms
 - security-scanning
 - test-driven-development
-template_version: 2.2.0
+template_version: 2.2.1
 template_changelog:
+- version: 2.2.6
+  date: '2026-06-09'
+  description: Align commit trailer to canonical Claude MPM format
 - version: 2.2.5
   date: '2026-06-09'
   description: Standardize AI-attribution footer to canonical MPM format with repo link
@@ -328,7 +331,7 @@ find . -type f -size +1000k -not -path "./.git/*" -not -path "./node_modules/*"
    
    🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
    
-   Co-Authored-By: Claude <noreply@anthropic.com>"
+   Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
    ```
 
 ### Prohibited Patterns

--- a/main/agents/claude-mpm/mpm-agent-manager.md
+++ b/main/agents/claude-mpm/mpm-agent-manager.md
@@ -396,7 +396,7 @@ Closes #{issue_number}
 
 ---
 🤖 Generated with Claude MPM Agent Manager
-Co-Authored-By: mpm-agent-manager <noreply@anthropic.com>
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 ```
 
 **3. Create PR via GitHub CLI**

--- a/main/agents/ops/core/ops.md
+++ b/main/agents/ops/core/ops.md
@@ -325,7 +325,7 @@ find . -type f -size +1000k -not -path "./.git/*" -not -path "./node_modules/*"
    
     Generated with [Claude Code](https://claude.ai/code)
    
-   Co-Authored-By: Claude <noreply@anthropic.com>"
+   Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
    ```
 
 ### Prohibited Patterns

--- a/templates/PM-INSTRUCTIONS.md
+++ b/templates/PM-INSTRUCTIONS.md
@@ -262,7 +262,7 @@ git commit -m "feat: add OAuth2 authentication
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 **Implementation commands require delegation**:
@@ -758,7 +758,7 @@ git commit -m "feat: add {description}
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 ### Before Ending Any Session

--- a/templates/base/base-engineer.md
+++ b/templates/base/base-engineer.md
@@ -238,7 +238,7 @@ type(scope): short description
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 ```
 
 **Conventional Commit Types**:

--- a/templates/circuit-breakers.md
+++ b/templates/circuit-breakers.md
@@ -484,7 +484,7 @@ git commit -m "<type>: <short description>
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 **Commit Type Prefixes** (Conventional Commits):
@@ -529,7 +529,7 @@ PM: Bash('git commit -m "feat: add New Agent template
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"')
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"')
 PM: "New agent template tracked in git with commit abc123"
 
 # Correct: PM verifies multiple files
@@ -544,7 +544,7 @@ PM: Bash('git commit -m "test: add comprehensive test suite
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"')
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"')
 PM: "All test files tracked in git"
 ```
 

--- a/templates/git-file-tracking.md
+++ b/templates/git-file-tracking.md
@@ -168,7 +168,7 @@ git commit -m "<type>: <short description>
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 **Template Structure:**
@@ -195,7 +195,7 @@ git commit -m "feat: add Java Engineer agent template
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 **Why This Example Works:**
@@ -218,7 +218,7 @@ git commit -m "docs: add agent performance benchmark results
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 **Why This Example Works:**
@@ -407,7 +407,7 @@ git commit -m "feat: add JVM language engineer templates
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 ### Files in Subdirectories
@@ -471,7 +471,7 @@ git commit -m "feat: add 8 new coding agent templates for v4.9.0 expansion
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 ```
 
 ### Files in .gitignore
@@ -538,7 +538,7 @@ git commit -m "type: description
 
 🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>"
 
 # 4. Verify commit
 git log -1


### PR DESCRIPTION
## Summary

Align all AI-generated commit trailers in the claude-mpm-agents repository from the stale Anthropic default to the canonical Claude MPM trailer format.

## Changes

### Agent Files Updated
- **agents/ops/core/ops.md**: Updated trailer + version bump 2.2.5 → 2.2.6 with changelog entry
- **agents/documentation/ticketing.md**: Updated trailer in example code
- **agents/claude-mpm/mpm-agent-manager.md**: Updated trailer in example code

### Template Files (Code Examples)
- **templates/base/base-engineer.md**: Updated commit message example (1 occurrence)
- **templates/circuit-breakers.md**: Fixed 3 occurrences in code examples
- **templates/PM-INSTRUCTIONS.md**: Fixed 2 occurrences in code examples  
- **templates/git-file-tracking.md**: Fixed 6 occurrences in code examples

### Legacy Files
- **main/agents/ops/core/ops.md**: Updated trailer
- **main/agents/claude-mpm/mpm-agent-manager.md**: Updated trailer

## Verification

✅ All 17 occurrences of `noreply@anthropic.com` have been replaced  
✅ Canonical trailer now consistent: `Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>`  
✅ Commit message templates use correct GitHub repo link  
✅ Version bump follows semantic versioning (PATCH: 2.2.5 → 2.2.6 for ops agent)  

## Related Issues

Closes #713