### PR TITLE
feat: port code-analyzer trusty-analyze tools + code-critic contract testing from claude-mpm

### DIFF
--- a/agents/qa/code-critic.md
+++ b/agents/qa/code-critic.md
@@ -127,6 +127,80 @@ If verdict is APPROVE with zero findings: omit the Findings table; write "No iss
 - **WARN** → report verdict + findings to PM; PM proceeds to next stage AND attaches finding table to Documentation agent handoff.
 - **BLOCK** → report verdict + findings to PM; PM HALTS pipeline and surfaces to user. Do not auto-route back to engineer.
 
+## Contract-Driven Testing
+
+When a function carries Code Contracts (preconditions, postconditions, invariants), derive a three-level testing pyramid directly from them. The contracts ARE the test plan.
+
+### Level 1 — Contract-Targeted Unit Tests
+
+- Read the contracts on the function under test — every precondition, postcondition, and invariant.
+- Write one focused test per postcondition. Derive the test name from the postcondition itself.
+- Test both the happy path and the boundary conditions for each postcondition.
+
+```python
+# Given postcondition: len(result) == min(k, len(items))
+def test_top_k_result_length_equals_min_k_items():
+    assert len(top_k([1.0, 2.0, 3.0], k=2)) == 2   # k < len
+    assert len(top_k([1.0, 2.0, 3.0], k=10)) == 3  # k > len
+```
+
+### Level 2 — Property-Based Tests from Contracts
+
+- Translate each postcondition into a property assertion.
+- Encode preconditions as generator constraints — not filter/rejection logic.
+- Use `hypothesis` (Python), `fast-check` (TypeScript/JS), or `quickcheck` (Rust).
+
+```python
+from hypothesis import given
+import hypothesis.strategies as st
+
+@given(
+    items=st.lists(st.floats(allow_nan=False), min_size=1),  # encodes: len(items) > 0
+    k=st.integers(min_value=1),                              # encodes: k > 0
+)
+def test_top_k_all_postconditions(items, k):
+    result = top_k(items, k)
+    assert len(result) <= len(items)                  # postcondition 1
+    assert len(result) == min(k, len(items))          # postcondition 2
+    assert all(x in items for x in result)            # postcondition 3
+```
+
+**Tip:** Python's `icontract-hypothesis` can auto-generate strategies from `icontract` decorators.
+
+### Level 3 — Precondition Violation Tests
+
+- Write one negative test per distinct precondition.
+- Verify the contract fails loudly with a useful message.
+- Verify that valid inputs never trigger spurious violations.
+
+```python
+def test_top_k_rejects_empty_items():
+    with pytest.raises(icontract.ViolationError, match="len\\(items\\) > 0"):
+        top_k([], k=1)
+
+def test_top_k_rejects_nonpositive_k():
+    with pytest.raises(icontract.ViolationError):
+        top_k([1.0, 2.0], k=0)
+```
+
+### When there are no contracts (yet)
+
+If the function under test has no contracts:
+
+1. Flag it for the engineer if the function is complex or critical.
+2. Infer implicit contracts from the function's docstring and observable behavior.
+3. Write property-based tests against the inferred properties anyway.
+
+### Contract review checklist
+
+When reviewing contracts written by the engineer:
+
+- [ ] Every postcondition references `result` — not just state side effects.
+- [ ] Relational postconditions present (ordering, identity) — not just existence.
+- [ ] No side effects in contract expressions.
+- [ ] `old()` used where mutation postconditions reference pre-call state.
+- [ ] Each contract has a corresponding Level 3 violation test.
+
 ## Memory Routing
 
 This agent stores patterns of recurring code issues so future critiques can pattern-match faster. Categories: code-quality-issues, recurring-bugs, verdict-patterns.

--- a/agents/qa/code-critic.md
+++ b/agents/qa/code-critic.md
@@ -173,6 +173,11 @@ def test_top_k_all_postconditions(items, k):
 - Verify the contract fails loudly with a useful message.
 - Verify that valid inputs never trigger spurious violations.
 
+Assert on the contract library's violation/exception type for the target language — the Python
+example below uses `icontract.ViolationError`; in other ecosystems use the equivalent assertion or
+guard failure (e.g. the precondition failure raised by `fast-check`/`quickcheck`-style contracts).
+The structure generalizes; only the exception type changes.
+
 ```python
 def test_top_k_rejects_empty_items():
     with pytest.raises(icontract.ViolationError, match="len\\(items\\) > 0"):
@@ -195,7 +200,7 @@ If the function under test has no contracts:
 
 When reviewing contracts written by the engineer:
 
-- [ ] Every postcondition references `result` — not just state side effects.
+- [ ] Postconditions on return-value functions reference `result`; postconditions on mutating functions reference the mutated object.
 - [ ] Relational postconditions present (ordering, identity) — not just existence.
 - [ ] No side effects in contract expressions.
 - [ ] `old()` used where mutation postconditions reference pre-call state.

--- a/agents/universal/code-analyzer.md
+++ b/agents/universal/code-analyzer.md
@@ -98,6 +98,11 @@ knowledge:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
+mcpServers:
+  trusty-analyze:
+    command: trusty-analyze
+    args:
+    - mcp
 skills:
   - universal-debugging-systematic-debugging
 ---
@@ -110,6 +115,55 @@ skills:
 ## Core Expertise
 
 Analyze code quality, detect patterns, identify improvements using AST analysis, and generate visual diagrams.
+
+## trusty-analyze MCP Tools (Preferred When Available)
+
+When `trusty-analyze` is running (port 7879) and `trusty-search` is running (port 7878), prefer
+these MCP tools over manual code analysis for indexed repositories:
+
+### Prerequisites
+- `trusty-search daemon` running on port 7878 (indexes the codebase)
+- `trusty-analyzer serve` running on port 7879 (analysis sidecar)
+- Repository must be indexed in trusty-search before analysis tools work
+
+### Check Availability First
+```
+mcp__trusty-analyze__analyzer_health
+```
+Returns `{ status: "ok", search_reachable: true }` when both daemons are running.
+If unavailable, fall back to the manual AST-based analysis described below.
+
+### Preferred Tools (use instead of manual analysis when available)
+
+| Task | trusty-analyze Tool | Manual Fallback |
+|------|---------------------|-----------------|
+| Find complex functions | `mcp__trusty-analyze__complexity_hotspots` | radon/ast analysis |
+| Detect code smells | `mcp__trusty-analyze__find_smells` | manual pattern checks |
+| Overall quality grade | `mcp__trusty-analyze__analyze_quality` | manual metrics aggregation |
+| Group related code | `mcp__trusty-analyze__cluster_concepts` | manual module review |
+| Query knowledge facts | `mcp__trusty-analyze__list_facts` | N/A (manual notes only) |
+
+### Tool Usage Examples
+
+```
+# Get the 20 most complex code chunks in an index
+mcp__trusty-analyze__complexity_hotspots  index_id="<id>"  top_k=20
+
+# Find all long-method and god-object smells
+mcp__trusty-analyze__find_smells  index_id="<id>"  category="long_method"
+
+# Get overall quality summary (A–F grade)
+mcp__trusty-analyze__analyze_quality  index_id="<id>"
+
+# Group chunks into concept clusters (k=8 default)
+mcp__trusty-analyze__cluster_concepts  index_id="<id>"  k=8  method="neural"
+```
+
+### When trusty-analyze Is Not Available
+Fall back to the manual analysis approach below. Do not block analysis waiting for the daemon
+to start — proceed immediately with AST-based tools.
+
+---
 
 ## Analysis Approach
 

--- a/agents/universal/code-analyzer.md
+++ b/agents/universal/code-analyzer.md
@@ -118,12 +118,13 @@ Analyze code quality, detect patterns, identify improvements using AST analysis,
 
 ## trusty-analyze MCP Tools (Preferred When Available)
 
-When `trusty-analyze` is running (port 7879) and `trusty-search` is running (port 7878), prefer
-these MCP tools over manual code analysis for indexed repositories:
+When `trusty-analyze` and `trusty-search` are running on their configured ports
+(defaults: trusty-analyze 7879, trusty-search 7878 — these can be overridden, so do not
+assume them), prefer these MCP tools over manual code analysis for indexed repositories:
 
 ### Prerequisites
-- `trusty-search daemon` running on port 7878 (indexes the codebase)
-- `trusty-analyzer serve` running on port 7879 (analysis sidecar)
+- `trusty-search daemon` running on its configured port (indexes the codebase)
+- `trusty-analyzer serve` running on its configured port (analysis sidecar)
 - Repository must be indexed in trusty-search before analysis tools work
 
 ### Check Availability First
@@ -132,6 +133,8 @@ mcp__trusty-analyze__analyzer_health
 ```
 Returns `{ status: "ok", search_reachable: true }` when both daemons are running.
 If unavailable, fall back to the manual AST-based analysis described below.
+If `search_reachable: false`, tools that depend on the search index (e.g. `complexity_hotspots`,
+`find_smells`, `cluster_concepts`) will fail — fall back to manual/AST analysis for those.
 
 ### Preferred Tools (use instead of manual analysis when available)
 
@@ -145,18 +148,22 @@ If unavailable, fall back to the manual AST-based analysis described below.
 
 ### Tool Usage Examples
 
+The snippets below are **illustrative pseudo-code**, not literal invocation syntax — each
+line shows the tool name followed by the conceptual parameters it takes. Pass the parameters
+using your MCP client's actual call format.
+
 ```
 # Get the 20 most complex code chunks in an index
-mcp__trusty-analyze__complexity_hotspots  index_id="<id>"  top_k=20
+mcp__trusty-analyze__complexity_hotspots(index_id="<id>", top_k=20)
 
 # Find all long-method and god-object smells
-mcp__trusty-analyze__find_smells  index_id="<id>"  category="long_method"
+mcp__trusty-analyze__find_smells(index_id="<id>", category="long_method")
 
 # Get overall quality summary (A–F grade)
-mcp__trusty-analyze__analyze_quality  index_id="<id>"
+mcp__trusty-analyze__analyze_quality(index_id="<id>")
 
 # Group chunks into concept clusters (k=8 default)
-mcp__trusty-analyze__cluster_concepts  index_id="<id>"  k=8  method="neural"
+mcp__trusty-analyze__cluster_concepts(index_id="<id>", k=8, method="neural")
 ```
 
 ### When trusty-analyze Is Not Available


### PR DESCRIPTION
These two changes upstream **project-local customizations** that have been living in `bobmatnyc/claude-mpm` (force-tracked under `.claude/agents/`) but were never present in this agent repo. Porting them here makes this repo the single source of truth so the customizations are not lost on the next agent deploy.

Refs: bobmatnyc/claude-mpm#862

## What was added

### `agents/universal/code-analyzer.md` (from claude-mpm commit `a89baec27`)
- **Frontmatter:** inlined the `mcpServers.trusty-analyze` block (`command: trusty-analyze`, `args: [mcp]`), scoping the analysis MCP to the code-analyzer agent context.
- **Body:** new `## trusty-analyze MCP Tools (Preferred When Available)` section — prerequisites (trusty-search :7878 / trusty-analyzer :7879), the `analyzer_health` availability check, a preferred-tools table (`complexity_hotspots`, `find_smells`, `analyze_quality`, `cluster_concepts`, `list_facts`), usage examples, and manual AST fallback guidance.

### `agents/qa/code-critic.md` (from claude-mpm commit `d08f65a69`)
- **Body:** new `## Contract-Driven Testing` section — the three-level testing pyramid derived from Code Contracts: Level 1 contract-targeted unit tests (one per postcondition), Level 2 property-based tests (preconditions as generator constraints via `hypothesis`/`fast-check`/`quickcheck`), Level 3 precondition violation tests, plus guidance for functions without contracts and a contract review checklist.
- Verified this content was **not already present** upstream (it is absent from `agents/qa/BASE-AGENT.md` and the QA base templates), so this is a genuine addition, not a duplicate.

## What was intentionally NOT ported
- Deployment-config / frontmatter differences that this repo manages its own way: `model`, `effort`, `color`, `agent_id`, `schema_version`, `version`, `temperature`, etc.
- The appended `BASE_QA` / `BASE_AGENT` instruction blocks visible in the *deployed* claude-mpm `code-critic.md` — those are composed at deploy time from base templates; porting them would double them.

## Validation
- YAML frontmatter for both files parses cleanly (`yaml.safe_load`).
- One file per commit; surgical additions only — all existing upstream content preserved.

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)