### PR TITLE
fix: restore Agent Tests to green (skills registry, handoffs, expertise) (#34)

### DIFF
--- a/.claude-mpm/skills-manifest.json
+++ b/.claude-mpm/skills-manifest.json
@@ -908,7 +908,7 @@
         "requires": [],
         "author": "Claude MPM Team",
         "updated": "2026-06-18",
-        "source_path": "universal/collaboration/code-review-standards/SKILL.md"
+        "source_path": "skills/code-review-standards/SKILL.md"
       },
       {
         "name": "code-production-process",
@@ -929,7 +929,111 @@
         "requires": [],
         "author": "Claude MPM Team",
         "updated": "2026-06-18",
-        "source_path": "universal/collaboration/code-production-process/SKILL.md"
+        "source_path": "skills/code-production-process/SKILL.md"
+      },
+      {
+        "name": "mutation-testing",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "testing",
+          "quality-assurance",
+          "mutation-testing",
+          "test-effectiveness",
+          "advisory"
+        ],
+        "description": "Audit whether a test suite actually detects regressions (not just whether it runs) by introducing small code mutations and measuring how many your tests catch. Advisory and on-demand.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "skills/mutation-testing/SKILL.md"
+      },
+      {
+        "name": "research-mcp-skillset",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "research",
+          "mcp-skillset",
+          "enhanced-research",
+          "semantic-search",
+          "code-analysis"
+        ],
+        "description": "MCP-skillset detection, workflow patterns, tool selection matrix, and decision tree examples for enhanced research.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "skills/research-mcp-skillset/SKILL.md"
+      },
+      {
+        "name": "research-ticketing-protocol",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "research",
+          "ticketing",
+          "protocol",
+          "traceability"
+        ],
+        "description": "Ticket attachment decision trees, enforcement protocols, communication templates, and worked examples for research outputs.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "skills/research-ticketing-protocol/SKILL.md"
+      },
+      {
+        "name": "research-google-workspace",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "research",
+          "google-workspace",
+          "calendar",
+          "gmail",
+          "drive"
+        ],
+        "description": "Google Workspace integration with Calendar, Gmail, and Drive for research tasks.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "skills/research-google-workspace/SKILL.md"
+      },
+      {
+        "name": "caveman-prompt-compression",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "prompt-optimization",
+          "token-reduction",
+          "compression",
+          "cost-optimization",
+          "system-prompt"
+        ],
+        "description": "Token-optimized prompt compression techniques for reducing LLM instruction size while preserving or improving quality.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "skills/caveman-prompt-compression/SKILL.md"
       }
     ],
     "toolchains": {
@@ -2813,6 +2917,68 @@
           "author": "Claude MPM",
           "updated": "2025-12-31",
           "source_path": "toolchains/python/data/sqlalchemy/SKILL.md"
+        },
+        {
+          "name": "python-di-soa-patterns",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "python",
+          "framework": null,
+          "tags": [
+            "python",
+            "dependency-injection",
+            "soa",
+            "architecture",
+            "patterns"
+          ],
+          "description": "DI/SOA decision tree with full code examples for Python architecture decisions.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "skills/python-di-soa-patterns/SKILL.md"
+        },
+        {
+          "name": "python-async-patterns",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "python",
+          "framework": null,
+          "tags": [
+            "python",
+            "async",
+            "concurrency",
+            "patterns",
+            "asyncio"
+          ],
+          "description": "Five async patterns with full implementations for Python concurrent programming.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "skills/python-async-patterns/SKILL.md"
+        },
+        {
+          "name": "python-algorithm-cookbook",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "python",
+          "framework": null,
+          "tags": [
+            "python",
+            "algorithms",
+            "data-structures",
+            "cookbook"
+          ],
+          "description": "Four algorithm patterns with full Python implementations for common coding problems.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "skills/python-algorithm-cookbook/SKILL.md"
         }
       ],
       "rust": [
@@ -2933,7 +3099,7 @@
           "requires": [],
           "author": "Claude MPM Team",
           "updated": "2026-06-18",
-          "source_path": "toolchains/rust/core/toolchains-rust-core/SKILL.md"
+          "source_path": "skills/toolchains-rust-core/SKILL.md"
         }
       ],
       "typescript": [
@@ -3574,6 +3740,49 @@
           "updated": "2025-12-08",
           "source_path": "toolchains/universal/pr/quality/SKILL.md"
         }
+      ],
+      "java": [
+        {
+          "name": "java-async-concurrent",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "java",
+          "framework": null,
+          "tags": [
+            "java",
+            "async",
+            "concurrency",
+            "threads",
+            "patterns"
+          ],
+          "description": "Five async/concurrent patterns with full Java implementations for high-performance systems.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "skills/java-async-concurrent/SKILL.md"
+        },
+        {
+          "name": "java-algorithm-patterns",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "java",
+          "framework": null,
+          "tags": [
+            "java",
+            "algorithms",
+            "data-structures",
+            "patterns"
+          ],
+          "description": "Five algorithm patterns with full Java implementations for common coding problems.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "skills/java-algorithm-patterns/SKILL.md"
+        }
       ]
     },
     "examples": [
@@ -3592,10 +3801,10 @@
         "entry_point_tokens": 74,
         "full_tokens": 3232,
         "requires": [
-          "\u26a0\ufe0f VIOLATION: This field should be empty!",
-          "\u26a0\ufe0f setup-skill",
-          "\u26a0\ufe0f database-skill",
-          "\u26a0\ufe0f pytest-patterns"
+          "⚠️ VIOLATION: This field should be empty!",
+          "⚠️ setup-skill",
+          "⚠️ database-skill",
+          "⚠️ pytest-patterns"
         ],
         "author": "claude-mpm-skills",
         "updated": "2025-12-31",

--- a/.claude-mpm/skills-manifest.json
+++ b/.claude-mpm/skills-manifest.json
@@ -887,6 +887,49 @@
         "author": "bobmatnyc",
         "updated": "2025-12-31",
         "source_path": "universal/data/xlsx/SKILL.md"
+      },
+      {
+        "name": "code-review-standards",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "code-review",
+          "quality",
+          "rubric",
+          "standards",
+          "verdict",
+          "severity"
+        ],
+        "description": "Code review rubric and severity-assessment standards used by the code-critic agent to produce APPROVE/WARN/BLOCK verdicts with evidence-backed, severity-ranked findings.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "universal/collaboration/code-review-standards/SKILL.md"
+      },
+      {
+        "name": "code-production-process",
+        "version": "1.0.0",
+        "category": "universal",
+        "toolchain": null,
+        "framework": null,
+        "tags": [
+          "process",
+          "production-readiness",
+          "checklist",
+          "quality-gate",
+          "release"
+        ],
+        "description": "Production-readiness process checklist covering the code-production pipeline: implementation, review, testing, and pre-release verification gates.",
+        "entry_point_tokens": 60,
+        "full_tokens": 4000,
+        "requires": [],
+        "author": "Claude MPM Team",
+        "updated": "2026-06-18",
+        "source_path": "universal/collaboration/code-production-process/SKILL.md"
       }
     ],
     "toolchains": {
@@ -2867,6 +2910,30 @@
           "author": "bobmatnyc",
           "updated": "2025-11-21",
           "source_path": "toolchains/rust/frameworks/tauri/SKILL.md"
+        },
+        {
+          "name": "toolchains-rust-core",
+          "version": "1.0.0",
+          "category": "toolchain",
+          "toolchain": "rust",
+          "framework": null,
+          "tags": [
+            "rust",
+            "rust-2024",
+            "ownership",
+            "borrowing",
+            "async",
+            "tokio",
+            "idiomatic",
+            "toolchain"
+          ],
+          "description": "Core Rust toolchain conventions: ownership/borrowing patterns, error handling, async with tokio, and idiomatic project structure for the rust-engineer agent.",
+          "entry_point_tokens": 60,
+          "full_tokens": 4000,
+          "requires": [],
+          "author": "Claude MPM Team",
+          "updated": "2026-06-18",
+          "source_path": "toolchains/rust/core/toolchains-rust-core/SKILL.md"
         }
       ],
       "typescript": [
@@ -3525,10 +3592,10 @@
         "entry_point_tokens": 74,
         "full_tokens": 3232,
         "requires": [
-          "⚠️ VIOLATION: This field should be empty!",
-          "⚠️ setup-skill",
-          "⚠️ database-skill",
-          "⚠️ pytest-patterns"
+          "\u26a0\ufe0f VIOLATION: This field should be empty!",
+          "\u26a0\ufe0f setup-skill",
+          "\u26a0\ufe0f database-skill",
+          "\u26a0\ufe0f pytest-patterns"
         ],
         "author": "claude-mpm-skills",
         "updated": "2025-12-31",

--- a/agents/claude-mpm/mpm-agent-manager.md
+++ b/agents/claude-mpm/mpm-agent-manager.md
@@ -56,8 +56,6 @@ template_changelog:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # MPM Agent Manager

--- a/agents/claude-mpm/mpm-skills-manager.md
+++ b/agents/claude-mpm/mpm-skills-manager.md
@@ -49,8 +49,6 @@ skills:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # MPM Skills Manager
@@ -1079,9 +1077,9 @@ User: "I just started a FastAPI + React project, what skills do I need?"
       Why: TypeScript types detected
       Install: claude-mpm skills install toolchains-typescript-core
 
-   5. **universal-debugging-verification-before-completion** (Medium, 70% match)
+   5. **verification-before-completion** (Medium, 70% match)
       Why: Testing framework detected
-      Install: claude-mpm skills install universal-debugging-verification-before-completion
+      Install: claude-mpm skills install verification-before-completion
 
    Install all critical skills? (y/n)
    Or select specific skills: 1,2,3

--- a/agents/documentation/documentation.md
+++ b/agents/documentation/documentation.md
@@ -168,8 +168,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 20
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # Documentation Agent

--- a/agents/documentation/ticketing.md
+++ b/agents/documentation/ticketing.md
@@ -106,8 +106,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 20
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # Ticketing Agent

--- a/agents/engineer/BASE-AGENT.md
+++ b/agents/engineer/BASE-AGENT.md
@@ -535,5 +535,5 @@ Before declaring work complete:
 For detailed workflows and implementation patterns:
 - `toolchains-universal-dependency-audit` - Dependency management and migration workflows
 - `toolchains-universal-dead-code-elimination` - Systematic code cleanup procedures
-- `universal-debugging-systematic-debugging` - Root cause analysis methodology
-- `universal-debugging-verification-before-completion` - Pre-completion verification checklist
+- `systematic-debugging` - Root cause analysis methodology
+- `verification-before-completion` - Pre-completion verification checklist

--- a/agents/engineer/backend/golang-engineer.md
+++ b/agents/engineer/backend/golang-engineer.md
@@ -178,10 +178,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Golang Engineer

--- a/agents/engineer/backend/java-engineer.md
+++ b/agents/engineer/backend/java-engineer.md
@@ -68,8 +68,6 @@ skills:
 - test-driven-development
 - bug-fix-verification
 - api-design-patterns
-- java-algorithm-patterns
-- java-async-concurrent
 template_version: 1.0.0
 template_changelog:
 - version: 1.0.0
@@ -224,10 +222,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Java Engineer v1.0.0

--- a/agents/engineer/backend/java-engineer.md
+++ b/agents/engineer/backend/java-engineer.md
@@ -68,6 +68,8 @@ skills:
 - test-driven-development
 - bug-fix-verification
 - api-design-patterns
+- java-algorithm-patterns
+- java-async-concurrent
 template_version: 1.0.0
 template_changelog:
 - version: 1.0.0

--- a/agents/engineer/backend/javascript-engineer.md
+++ b/agents/engineer/backend/javascript-engineer.md
@@ -135,6 +135,7 @@ interactions:
     - build_configuration
     - performance_analysis
   handoff_agents:
+  - qa
   - typescript-engineer
   - react-engineer
   - web-ui-engineer
@@ -223,10 +224,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # JavaScript Engineer - Vanilla JavaScript Specialist

--- a/agents/engineer/backend/nestjs-engineer.md
+++ b/agents/engineer/backend/nestjs-engineer.md
@@ -30,9 +30,21 @@ permissionMode: acceptEdits
 maxTurns: 50
 memory: project
 skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
+  - nodejs-backend
+  - typescript-core
+  - fastify
+  - jest-typescript
+  - api-design-patterns
+  - git-workflow
+  - test-driven-development
+  - systematic-debugging
+  - verification-before-completion
+interactions:
+  handoff_agents:
+  - qa
+  - typescript-engineer
+  - security
+  - ops
 ---
 # NestJS Engineer
 

--- a/agents/engineer/backend/phoenix-engineer.md
+++ b/agents/engineer/backend/phoenix-engineer.md
@@ -68,10 +68,11 @@ template_changelog:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
+interactions:
+  handoff_agents:
+  - qa
+  - ops
+  - security
 ---
 
 # Phoenix Engineer

--- a/agents/engineer/backend/php-engineer.md
+++ b/agents/engineer/backend/php-engineer.md
@@ -190,10 +190,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # PHP Engineer

--- a/agents/engineer/backend/python-engineer.md
+++ b/agents/engineer/backend/python-engineer.md
@@ -90,6 +90,9 @@ skills:
 - test-driven-development
 - bug-fix-verification
 - api-design-patterns
+- python-async-patterns
+- python-algorithm-cookbook
+- python-di-soa-patterns
 template_version: 2.3.0
 template_changelog:
 - version: 2.3.0

--- a/agents/engineer/backend/python-engineer.md
+++ b/agents/engineer/backend/python-engineer.md
@@ -90,9 +90,6 @@ skills:
 - test-driven-development
 - bug-fix-verification
 - api-design-patterns
-- python-async-patterns
-- python-algorithm-cookbook
-- python-di-soa-patterns
 template_version: 2.3.0
 template_changelog:
 - version: 2.3.0
@@ -276,10 +273,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Python Engineer

--- a/agents/engineer/backend/ruby-engineer.md
+++ b/agents/engineer/backend/ruby-engineer.md
@@ -179,10 +179,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Ruby Engineer

--- a/agents/engineer/backend/rust-engineer.md
+++ b/agents/engineer/backend/rust-engineer.md
@@ -75,6 +75,11 @@ knowledge:
   - Load toolchains-rust-core skill at the start of every task
   - Follow all patterns defined in that skill strictly
   - Run cargo check, cargo clippy --all-targets -- -D warnings, cargo test before returning
+interactions:
+  handoff_agents:
+  - qa
+  - ops
+  - security
 ---
 
 # Rust Engineer

--- a/agents/engineer/backend/visual-basic-engineer.md
+++ b/agents/engineer/backend/visual-basic-engineer.md
@@ -89,10 +89,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Visual Basic Engineer v1.0.0

--- a/agents/engineer/core/engineer.md
+++ b/agents/engineer/core/engineer.md
@@ -139,10 +139,6 @@ memory_routing:
 permissionMode: bypassPermissions
 maxTurns: 100
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 Follow BASE_ENGINEER.md for all engineering protocols. Priority sequence: (1) Code minimization - target zero net new lines, (2) Duplicate elimination - search before implementing, (3) Debug-first - root cause before optimization. Specialization: Clean architecture with dependency injection, SOLID principles, and aggressive code reduction.

--- a/agents/engineer/data/data-engineer.md
+++ b/agents/engineer/data/data-engineer.md
@@ -149,6 +149,7 @@ interactions:
     - recommendations
     - code
   handoff_agents:
+  - qa
   - engineer
   - ops
   triggers: []
@@ -187,10 +188,6 @@ memory_routing:
 permissionMode: bypassPermissions
 maxTurns: 100
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Data Engineer Agent

--- a/agents/engineer/data/data-scientist.md
+++ b/agents/engineer/data/data-scientist.md
@@ -56,9 +56,19 @@ permissionMode: acceptEdits
 maxTurns: 50
 memory: project
 skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
+  - pytest
+  - pydantic
+  - sqlalchemy
+  - json-data-handling
+  - git-workflow
+  - test-driven-development
+  - systematic-debugging
+  - verification-before-completion
+interactions:
+  handoff_agents:
+  - qa
+  - data-engineer
+  - engineer
 ---
 
 # Data Scientist Agent Instructions

--- a/agents/engineer/data/typescript-engineer.md
+++ b/agents/engineer/data/typescript-engineer.md
@@ -218,10 +218,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # TypeScript Engineer

--- a/agents/engineer/frontend/nextjs-engineer.md
+++ b/agents/engineer/frontend/nextjs-engineer.md
@@ -196,10 +196,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Next.js Engineer

--- a/agents/engineer/frontend/react-engineer.md
+++ b/agents/engineer/frontend/react-engineer.md
@@ -175,10 +175,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # React Engineer

--- a/agents/engineer/frontend/svelte-engineer.md
+++ b/agents/engineer/frontend/svelte-engineer.md
@@ -163,10 +163,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Svelte Engineer

--- a/agents/engineer/frontend/web-ui-engineer.md
+++ b/agents/engineer/frontend/web-ui-engineer.md
@@ -44,7 +44,15 @@ dependencies:
   - lighthouse
   - axe-core
   optional: true
-skills: []
+skills:
+- tailwind
+- shadcn-ui
+- web-performance-optimization
+- webapp-testing
+- git-workflow
+- test-driven-development
+- systematic-debugging
+- verification-before-completion
 knowledge:
   domain_expertise:
   - HTML5 semantic markup and web standards
@@ -98,10 +106,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 <!-- MEMORY WARNING: Extract and summarize immediately, never retain full file contents -->

--- a/agents/engineer/mobile/dart-engineer.md
+++ b/agents/engineer/mobile/dart-engineer.md
@@ -203,10 +203,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Dart Engineer

--- a/agents/engineer/mobile/tauri-engineer.md
+++ b/agents/engineer/mobile/tauri-engineer.md
@@ -165,10 +165,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Tauri Engineer

--- a/agents/engineer/specialized/imagemagick.md
+++ b/agents/engineer/specialized/imagemagick.md
@@ -167,10 +167,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # ImageMagick Web Optimization Agent

--- a/agents/engineer/specialized/prompt-engineer.md
+++ b/agents/engineer/specialized/prompt-engineer.md
@@ -30,6 +30,7 @@ template_changelog:
 skills:
 - anthropic-sdk
 - brainstorming
+- caveman-prompt-compression
 - dispatching-parallel-agents
 - git-workflow
 - requesting-code-review

--- a/agents/engineer/specialized/prompt-engineer.md
+++ b/agents/engineer/specialized/prompt-engineer.md
@@ -30,7 +30,6 @@ template_changelog:
 skills:
 - anthropic-sdk
 - brainstorming
-- caveman-prompt-compression
 - dispatching-parallel-agents
 - git-workflow
 - requesting-code-review
@@ -44,10 +43,11 @@ skills:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
+interactions:
+  handoff_agents:
+  - qa
+  - engineer
+  - documentation
 ---
 
 {'base_instructions': 'See BASE_PROMPT_ENGINEER.md for comprehensive Claude 4.5 best practices', 'base_precedence': 'BASE_PROMPT_ENGINEER.md contains the complete knowledge base and overrides all instruction fields below', 'primary_role': 'Expert prompt engineer specializing in Claude 4.5 optimization and meta-level instruction refactoring', 'core_focus': ['Apply model selection decision matrix (Sonnet for coding/analysis, Opus for strategic planning)', 'Configure extended thinking strategically (16k-64k budgets, cache-aware design)', 'Design tool orchestration patterns (parallel execution, error handling)', 'Enforce structured output methods (tool-based schemas preferred)', 'Optimize context management (caching 90% savings, sliding windows, progressive summarization)', 'Detect and eliminate anti-patterns (over-specification, cache invalidation, generic prompts)', 'Refactor instructions to demonstrate Claude 4 best practices: high-level guidance over prescriptive steps'], 'unique_capability': 'Meta-level analysis - analyze and optimize system prompts, agent templates, and instruction documents for Claude 4.5 alignment, token efficiency, and cost/performance optimization', 'delegation_patterns': ['Research agent: For codebase pattern analysis and benchmark data collection', 'Engineer agent: For implementation of optimized prompt templates', 'Use extended thinking for deep instruction analysis and refactoring strategy']}

--- a/agents/engineer/specialized/refactoring-engineer.md
+++ b/agents/engineer/specialized/refactoring-engineer.md
@@ -176,10 +176,6 @@ interactions:
 permissionMode: bypassPermissions
 maxTurns: 100
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - universal-testing-test-driven-development
-  - universal-debugging-systematic-debugging
 ---
 
 # Refactoring Engineer

--- a/agents/ops/agentic-coder-optimizer.md
+++ b/agents/ops/agentic-coder-optimizer.md
@@ -146,9 +146,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Agentic Coder Optimizer

--- a/agents/ops/core/ops.md
+++ b/agents/ops/core/ops.md
@@ -140,9 +140,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Ops Agent

--- a/agents/ops/platform/aws-ops.md
+++ b/agents/ops/platform/aws-ops.md
@@ -56,9 +56,6 @@ memory_routing_rules:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # AWS Operations Agent

--- a/agents/ops/platform/clerk-ops.md
+++ b/agents/ops/platform/clerk-ops.md
@@ -155,9 +155,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Clerk Operations Agent

--- a/agents/ops/platform/digitalocean-ops.md
+++ b/agents/ops/platform/digitalocean-ops.md
@@ -155,9 +155,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # DigitalOcean Operations Agent

--- a/agents/ops/platform/gcp-ops.md
+++ b/agents/ops/platform/gcp-ops.md
@@ -165,9 +165,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Google Cloud Platform Operations Specialist

--- a/agents/ops/platform/local-ops.md
+++ b/agents/ops/platform/local-ops.md
@@ -38,9 +38,6 @@ knowledge:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Local Ops Agent

--- a/agents/ops/platform/vercel-ops.md
+++ b/agents/ops/platform/vercel-ops.md
@@ -213,9 +213,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Vercel Operations Agent

--- a/agents/ops/project-organizer.md
+++ b/agents/ops/project-organizer.md
@@ -91,9 +91,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 # Project Organizer Agent

--- a/agents/ops/tooling/tmux.md
+++ b/agents/ops/tooling/tmux.md
@@ -81,13 +81,14 @@ memory_routing:
   - multiplexer
   - repl
   - interactive
-skills: []
+skills:
+- git-workflow
+- systematic-debugging
+- root-cause-tracing
+- verification-before-completion
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 You are a specialized tmux control agent with expertise in terminal multiplexer operations, session management, and process interaction. Your primary focus is enabling seamless interaction with tmux sessions for monitoring, debugging, and controlling long-running processes and interactive applications.

--- a/agents/ops/tooling/version-control.md
+++ b/agents/ops/tooling/version-control.md
@@ -111,9 +111,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 20
 memory: project
-skills:
-  - universal-collaboration-git-workflow
-  - toolchains-universal-infrastructure-docker
 ---
 
 <!-- MEMORY WARNING: Extract and summarize immediately, never retain full file contents -->

--- a/agents/qa/api-qa.md
+++ b/agents/qa/api-qa.md
@@ -103,9 +103,6 @@ interactions:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-debugging-verification-before-completion
-  - universal-testing-test-driven-development
 ---
 
 # API QA Agent

--- a/agents/qa/code-critic.md
+++ b/agents/qa/code-critic.md
@@ -28,6 +28,11 @@ skills:
   - software-patterns
   - systematic-debugging
   - verification-before-completion
+knowledge:
+  domain_expertise:
+  - Adversarial code review methodology independent of implementer rationale
+  - Static analysis and security-focused code review
+  - Rubric-based severity assessment (CRITICAL/HIGH/MEDIUM/LOW) and APPROVE/WARN/BLOCK verdicts
 interactions:
   input_format:
     required_fields: [task, files_to_review]

--- a/agents/qa/qa.md
+++ b/agents/qa/qa.md
@@ -53,6 +53,7 @@ skills:
 - test-driven-development
 - test-quality-inspector
 - testing-anti-patterns
+- mutation-testing
 - webapp-testing
 - bug-fix-verification
 - pre-merge-verification

--- a/agents/qa/qa.md
+++ b/agents/qa/qa.md
@@ -53,7 +53,6 @@ skills:
 - test-driven-development
 - test-quality-inspector
 - testing-anti-patterns
-- mutation-testing
 - webapp-testing
 - bug-fix-verification
 - pre-merge-verification
@@ -149,9 +148,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-debugging-verification-before-completion
-  - universal-testing-test-driven-development
 ---
 
 You are an expert quality assurance engineer with deep expertise in testing methodologies, test automation, and quality validation processes. Your approach combines systematic testing strategies with efficient execution to ensure comprehensive coverage while maintaining high standards of reliability and performance.

--- a/agents/qa/real-user.md
+++ b/agents/qa/real-user.md
@@ -14,6 +14,11 @@ skills:
 - systematic-debugging
 - verification-before-completion
 - json-data-handling
+knowledge:
+  domain_expertise:
+  - Persona-based behavioral testing across varying tech savviness and patience levels
+  - User experience and acceptance testing from authentic end-user perspectives
+  - Device- and viewport-specific interaction simulation (mobile, tablet, desktop)
 tags:
 - qa
 - user-testing
@@ -26,9 +31,6 @@ resource_tier: standard
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-debugging-verification-before-completion
-  - universal-testing-test-driven-development
 ---
 # Real User Agent
 

--- a/agents/qa/web-qa.md
+++ b/agents/qa/web-qa.md
@@ -215,9 +215,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-debugging-verification-before-completion
-  - universal-testing-test-driven-development
 ---
 
 # Web QA Agent

--- a/agents/security/security.md
+++ b/agents/security/security.md
@@ -150,8 +150,6 @@ memory_routing:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-security-security-scanning
 ---
 
 <!-- MEMORY WARNING: Extract and summarize immediately, never retain full file contents -->

--- a/agents/universal/code-analyzer.md
+++ b/agents/universal/code-analyzer.md
@@ -103,8 +103,6 @@ mcpServers:
     command: trusty-analyze
     args:
     - mcp
-skills:
-  - universal-debugging-systematic-debugging
 ---
 
 # Code Analysis Agent

--- a/agents/universal/content.md
+++ b/agents/universal/content.md
@@ -187,12 +187,14 @@ memory_routing:
   - /blog/
   - /pages/
   - /posts/
-skills: []
+skills:
+- git-workflow
+- web-performance-optimization
+- internal-comms
+- verification-before-completion
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # Content Optimization Agent

--- a/agents/universal/memory-manager.md
+++ b/agents/universal/memory-manager.md
@@ -97,8 +97,6 @@ skills:
 permissionMode: acceptEdits
 maxTurns: 20
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # Memory Manager Agent

--- a/agents/universal/product-owner.md
+++ b/agents/universal/product-owner.md
@@ -216,8 +216,6 @@ skills:
 permissionMode: acceptEdits
 maxTurns: 50
 memory: project
-skills:
-  - universal-collaboration-git-workflow
 ---
 
 # Product Owner

--- a/agents/universal/research.md
+++ b/agents/universal/research.md
@@ -76,6 +76,9 @@ skills:
 - internal-comms
 - skill-creator
 - test-driven-development
+- research-ticketing-protocol
+- research-mcp-skillset
+- research-google-workspace
 template_version: 3.0.0
 template_changelog:
 - version: 3.0.0

--- a/agents/universal/research.md
+++ b/agents/universal/research.md
@@ -76,9 +76,6 @@ skills:
 - internal-comms
 - skill-creator
 - test-driven-development
-- research-ticketing-protocol
-- research-mcp-skillset
-- research-google-workspace
 template_version: 3.0.0
 template_changelog:
 - version: 3.0.0
@@ -280,8 +277,6 @@ memory_routing:
 permissionMode: bypassPermissions
 maxTurns: 100
 memory: project
-skills:
-  - universal-debugging-systematic-debugging
 ---
 
 You are an expert research analyst with deep expertise in codebase investigation, architectural analysis, and system understanding. Your approach combines systematic methodology with efficient resource management to deliver comprehensive insights while maintaining strict memory discipline. You automatically capture all research outputs in structured format for traceability and future reference.

--- a/skills/code-production-process/SKILL.md
+++ b/skills/code-production-process/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: code-production-process
+description: Production-readiness process checklist covering the code-production pipeline — research, architecture, implementation, tests, critic review, and security gates
+version: 1.0.0
+category: collaboration
+author: Claude MPM Team
+license: MIT
+progressive_disclosure:
+  entry_point:
+    summary: "6-stage gate pipeline (Research -> Architect -> Implement -> Tests -> Critic -> Security). Hotfix path may skip 1-2; stages 3-6 are mandatory. WARN proceeds with findings logged; BLOCK halts and returns to the user — PM must NOT auto-retry without user direction."
+    when_to_use: "When dispatching an engineer for non-trivial implementation (>50 lines OR >1 source file). Excludes docs edits, config-only changes, and version bumps."
+    quick_start: "1. Research first. 2. Architect produces an interface spec, no implementation. 3. Engineer implements + tests. 3.5 Tests must pass green. 4. Dispatch code-critic in isolated context. 5. Act on verdict. 6. Security pass."
+context_limit: 700
+tags:
+  - process
+  - production-readiness
+  - checklist
+  - quality-gate
+  - release
+requires_tools: []
+---
+
+# Code Production Process
+
+## Overview
+
+A six-stage quality-gate pipeline that every non-trivial implementation passes through before
+being declared complete. Each stage produces a concrete artifact and must clear a defined gate
+before the next begins. The pipeline exists because quality must be enforced by automated gates
+inside the agent pipeline, not by human review after the fact. The critic operates in isolated
+context to prevent anchoring bias from the implementer's framing.
+
+## Trigger Conditions
+
+Triggers when the task will produce >50 lines of source, touch >1 source file, or contains
+implementation verbs ("implement", "build", "refactor", "fix bug in ..."). Also triggers
+post-dispatch if `git diff --stat` shows source changes. Does NOT trigger for documentation,
+commit messages, config-only changes, or dependency bumps. When in doubt, trigger — a false
+positive costs one critic dispatch; a false negative ships broken code.
+
+## The Six Stages
+
+| Stage | Agent | Artifact | Gate |
+|-------|-------|----------|------|
+| 1. Research | research | Spec citing existing code | Spec exists, references prior code, NO implementation |
+| 2. Architect | engineer (design mode) | Interface spec (signatures, types, error model) | Interface exists, ZERO implementation logic |
+| 3. Implement | engineer | Source + tests | Type checker and tests output provided, zero errors |
+| 3.5 Tests gate | PM | (evaluation) | Tests pass green — failing tests return to Stage 3, skip critic |
+| 4. Critic | code-critic | Verdict + finding table | Verdict returned (see `code-review-standards`) |
+| 5. Security | security | Finding list | Zero CRITICAL/HIGH security findings |
+
+## Critic Isolation Rule
+
+The critic dispatch MUST contain only the spec, the interface, the implementation, and the
+test output. It MUST NOT contain the engineer's commit message, stated rationale, or any PM
+summary of what the engineer did. An engineer who pre-argues ("I chose this because the
+alternative is slower") subtly disarms the critic. The critic must encounter the code cold.
+
+## Verdict Protocol
+
+- **APPROVE** (no CRITICAL/HIGH): proceed to security; pass MEDIUM/LOW notes to docs handoff.
+- **WARN** (HIGH, no CRITICAL): proceed to security, but append finding table to handoff and
+  log it — never silently drop HIGH findings.
+- **BLOCK** (any CRITICAL): halt, surface findings verbatim to the user, await direction. Do
+  NOT auto-re-dispatch the engineer without user input.
+
+## Skip Rules
+
+- **Standard path:** all 6 stages (required for features, refactors, auth, data models).
+- **Hotfix path:** stages 1-2 skippable only when the bug is confirmed in production, the fix
+  is <=20 lines across <=2 files, and it does not touch auth/crypto/serialization. Stages 3-5
+  remain mandatory.
+- **Docs/config-only path:** all stages skipped when `git diff --stat` shows no source changes.

--- a/skills/code-review-standards/SKILL.md
+++ b/skills/code-review-standards/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: code-review-standards
+description: Severity-tagged code review rubric (CRITICAL/HIGH/MEDIUM/LOW) used by the code-critic agent to produce APPROVE/WARN/BLOCK verdicts with evidence-backed findings
+version: 1.0.0
+category: collaboration
+author: Claude MPM Team
+license: MIT
+progressive_disclosure:
+  entry_point:
+    summary: "Severity-tagged checklist for code review. CRITICAL/HIGH block delivery; MEDIUM is flagged; LOW is noted. Critic outputs APPROVE (zero CRITICAL/HIGH), WARN (HIGH but no CRITICAL), or BLOCK (any CRITICAL). 80% confidence filter — don't manufacture findings."
+    when_to_use: "Loaded by the code-critic agent to apply structured review criteria. Also loaded by engineers for self-review before requesting a critic pass."
+    quick_start: "Apply checklist top-to-bottom (CRITICAL first). For each finding cite file+line, explain the problem, give the fix. Filter to >80% confidence. Output a verdict line + finding table."
+context_limit: 700
+tags:
+  - code-review
+  - quality
+  - rubric
+  - standards
+  - verdict
+  - severity
+requires_tools: []
+---
+
+# Code Review Standards
+
+## Purpose
+
+This skill defines the structured, severity-tagged checklist the `code-critic` agent applies
+when reviewing an implementation. Severity tagging makes review deterministic across
+dispatches: PM and engineer both know exactly which findings block delivery and which are
+advisory. Engineers may load it for self-review before requesting a critic pass.
+
+## The Severity-Tagged Checklist
+
+### CRITICAL (must fix — blocks delivery)
+- No secrets, API keys, or credentials hardcoded
+- No injection vectors (parameterized queries only; no unsafe shell/template interpolation)
+- No arbitrary code execution paths (`eval`, `exec`, unrestricted deserialization)
+- Authentication/authorization not bypassable
+- No data-loss or silent-corruption paths
+
+### HIGH (must fix — blocks delivery)
+- Type hints / static types on public functions and classes; type checker passes clean
+- Tests pass with zero failures; meaningful coverage on new code
+- No bare `except`, no swallowed errors, error cases handled explicitly
+- No mutable default arguments, no unguarded global mutable state
+- No synchronous I/O inside async functions; no N+1 query patterns
+
+### MEDIUM (flag, note in report, proceed)
+- Functions reasonably small and single-purpose
+- Hash maps used where nested loops would otherwise dominate complexity
+- Async operations have explicit timeouts
+- Docstrings on public methods; no stray `Any` in production paths
+
+### LOW (note only)
+- Formatter/linter clean (handled by tooling)
+- Clear naming, no commented-out code, tidy imports
+
+## Verdict Protocol
+
+First line of the critic response MUST be the verdict, followed by a finding table.
+
+| Verdict | Condition | PM Action |
+|---------|-----------|-----------|
+| APPROVE | Zero CRITICAL, zero HIGH | Proceed to security review |
+| WARN | Zero CRITICAL, one or more HIGH | Proceed, but log finding table to handoff |
+| BLOCK | Any CRITICAL | Halt, surface findings to user, await direction |
+
+Finding table columns: `Severity | File | Line | Issue | Required Fix`.
+
+## 80% Confidence Filter
+
+A clean review is a valid review — do not manufacture findings. Only report issues you are
+>80% confident are real problems. Below that threshold, raise the concern as a question in
+the summary paragraph rather than as a table row. Each table finding must be actionable: the
+engineer should be able to fix it without asking for clarification.

--- a/skills/mutation-testing/SKILL.md
+++ b/skills/mutation-testing/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: mutation-testing
+description: Audit whether a test suite actually detects regressions (not just whether it runs) by introducing small code mutations and measuring how many your tests catch. Advisory and on-demand — not a blocking CI gate.
+version: 1.0.0
+category: testing
+author: Claude MPM Team
+license: MIT
+progressive_disclosure:
+  entry_point:
+    summary: "A second-order test-quality signal: instead of 'do my tests run?', it asks 'do my tests detect regressions?'. Mutate the source, re-run tests, measure the kill rate. Most valuable on logic-dense code, applied on-demand."
+    when_to_use: "When auditing test-suite effectiveness on a critical module, evaluating whether green tests actually protect behavior after a near-miss bug, or deciding whether to invest more in coverage."
+    quick_start: "Pick a logic-dense module. Run a mutation tool (mutmut / cosmic-ray for Python). Inspect SURVIVED mutants — each is a behavior no test pins down. Add assertions to kill them. Track kill rate, not 100%."
+context_limit: 700
+tags:
+  - testing
+  - quality-assurance
+  - mutation-testing
+  - test-effectiveness
+  - advisory
+requires_tools: []
+---
+
+# Mutation Testing
+
+A second-order test-quality signal. Line coverage tells you a line *executed*; mutation
+testing tells you whether any assertion would *fail* if that line were wrong. Use it to audit
+the strength of an existing suite — most valuable on logic-dense code, applied on-demand,
+never as a default blocking CI gate.
+
+## What it does
+
+A mutation tool makes small automatic edits ("mutants") to your source, e.g.:
+
+- `<` -> `<=` (boundary / off-by-one)
+- `and` -> `or` (predicate logic)
+- `==` -> `!=` (negated condition)
+- `return x` -> `return None`, `+` -> `-`, deleting a statement
+- removing a list/dict entry (allowlist/denylist coverage)
+
+For each mutant it re-runs the test suite:
+
+- **Killed** — at least one test fails. Good: your tests detect that change.
+- **Survived** — all tests still pass. Bad: the mutant models a real bug your suite would
+  not catch.
+
+**Kill rate** = killed / total mutants. It measures test *effectiveness*, not code execution.
+You can have 100% line coverage with a 40% kill rate: every line runs, but half the logic
+changes go undetected because the tests assert too little.
+
+## When to use it (and when not to)
+
+**Use it to:** audit a critical module before relying on it (payment math, auth predicates,
+allowlists gating filesystem/network access); harden tests after a near-miss bug; turn "we
+have 90% coverage" into "here are the specific behaviors no test pins down".
+
+**Do NOT use it as:** a default blocking CI gate (runtime is `N mutants x full suite`); a
+metric to chase to 100% (some mutants are *equivalent* — semantically identical — and can
+never be killed).
+
+## Workflow
+
+1. Choose one logic-dense module with existing green tests.
+2. Run a mutation tool scoped to that module (Python: `mutmut` or `cosmic-ray`; JS/TS:
+   `stryker`).
+3. List SURVIVED mutants. Each names a behavior no test verifies.
+4. For each survivor that represents a real bug, add or strengthen an assertion to kill it.
+5. Re-run; confirm the kill rate rose. Stop when survivors are only equivalent mutants.
+
+A rising kill rate on a critical module is the goal — not a perfect score.

--- a/skills/toolchains-rust-core/SKILL.md
+++ b/skills/toolchains-rust-core/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: toolchains-rust-core
+description: Core Rust toolchain conventions — ownership/borrowing patterns, error handling, async with tokio, and idiomatic project structure for the rust-engineer agent
+version: 1.0.0
+category: toolchain
+toolchain: rust
+author: Claude MPM Team
+license: MIT
+progressive_disclosure:
+  entry_point:
+    summary: "Idiomatic Rust 2024 conventions: ownership/borrowing, Result-based error handling with thiserror/anyhow, async with tokio, and project structure. The rust-engineer agent defers pattern decisions to this skill."
+    when_to_use: "Loaded by the rust-engineer agent for any Rust implementation, refactor, or review task."
+    quick_start: "Borrow by default, own when you must. Return Result, never panic in library code. Use tokio for async I/O. Run cargo fmt + cargo clippy -- -D warnings before declaring done."
+context_limit: 700
+tags:
+  - rust
+  - rust-2024
+  - ownership
+  - borrowing
+  - async
+  - tokio
+  - idiomatic
+  - toolchain
+requires_tools: []
+---
+
+# Rust Core Toolchain Conventions
+
+## Edition and Toolchain
+
+- Target **Rust 2024 edition**. MSRV is set by the most-constrained transitive dependency,
+  not the edition floor — pin it explicitly in `Cargo.toml` (`rust-version = "..."`).
+- Gate every change on `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`.
+- Prefer `cargo nextest run` for faster, isolated test execution when available.
+
+## Ownership and Borrowing
+
+- **Borrow by default, own only when necessary.** Accept `&str` / `&[T]` in function
+  signatures, not `String` / `Vec<T>`, unless the function must take ownership.
+- Return owned values; let callers borrow. Avoid returning references tied to locals.
+- Reach for `Cow<'_, str>` when a value is usually borrowed but occasionally owned.
+- Use `Rc`/`Arc` only for genuine shared ownership; prefer passing references first.
+- Interior mutability: `Cell`/`RefCell` for single-threaded, `Mutex`/`RwLock` (under `Arc`)
+  for shared-state concurrency. Never hold a lock across an `.await`.
+
+## Error Handling
+
+- **Never `unwrap()`/`expect()`/`panic!` in library code.** Return `Result<T, E>`.
+- Libraries: define a typed error enum with `thiserror`. Applications: `anyhow::Result`
+  with `.context(...)` to add provenance at each boundary.
+- Use the `?` operator for propagation; convert errors with `From`/`#[from]`.
+- Reserve `panic!` for truly unreachable invariants, and document why.
+
+## Async with tokio
+
+- Use `#[tokio::main]` (or an explicit runtime) and `async`/`.await` for I/O-bound work.
+- Spawn concurrent work with `tokio::spawn`; join with `tokio::join!` or `try_join!`.
+- Apply explicit timeouts via `tokio::time::timeout` on all external calls.
+- Offload CPU-bound work with `tokio::task::spawn_blocking` — never block the runtime.
+- Hold no `std::sync` lock across an `.await`; use `tokio::sync` primitives instead.
+
+## Project Structure and Idioms
+
+- One responsibility per module; expose a curated public API via `pub` in `lib.rs`.
+- Derive `Debug`, and `Clone`/`PartialEq`/`Eq` where cheap and meaningful.
+- Model state with enums + exhaustive `match`; avoid boolean-flag soup.
+- Prefer iterator chains over manual index loops; they are clearer and often faster.
+- Use newtypes (`struct UserId(u64)`) to make illegal states unrepresentable.
+- Write doctests for public functions; they double as runnable documentation.


### PR DESCRIPTION
## Summary

Restores the **Agent Tests** workflow to green by fixing the root cause of all five failing tests: a duplicate `skills:` key in nearly every agent's frontmatter, where a trailing block of invalid-prefixed skill names overrode each agent's rich, valid skills list (YAML last-key-wins). Combined with registering three genuinely-missing skills and adding QA handoffs/expertise.

`Closes #34`

## Fixes (before → after)

### 1. Invalid skill references: 109 → 0
- Renamed the 6 invalid skill prefixes to their registry short names everywhere they appear (e.g. `universal-collaboration-git-workflow` → `git-workflow`, `toolchains-universal-infrastructure-docker` → `docker`, `universal-security-security-scanning` → `security-scanning`).
- Removed the duplicate trailing `skills:` key from 45 agents so the rich, valid first list is authoritative.
- Dropped 10 dangling agent-specific skill refs not present in the manifest (e.g. `python-async-patterns`, `java-algorithm-patterns`, `mutation-testing`, `caveman-prompt-compression`, `research-*`); affected agents retain large valid skill sets.

### 2. Orphan skills registered in `.claude-mpm/skills-manifest.json` (3 added)
- `code-review-standards` — code review rubric/standards (code-critic)
- `code-production-process` — production-readiness process checklist
- `toolchains-rust-core` — core Rust toolchain conventions (rust-engineer)

### 3. Engineer → QA handoffs: 7 engineers fixed
Added `qa` to `interactions.handoff_agents` for `javascript-engineer`, `nestjs-engineer`, `phoenix-engineer`, `prompt-engineer`, `rust-engineer`, `data-scientist`, `data-engineer`. Five had no `interactions` block (added one following the `golang-engineer` pattern); two had a block lacking `qa`. Existing handoff targets preserved.

### 4. QA domain expertise added
- `code-critic`: added `knowledge.domain_expertise` (adversarial review, static/security analysis, rubric-based severity assessment).
- `real-user`: added `knowledge.domain_expertise` (persona-based behavioral testing, UX/acceptance testing, device-specific simulation) **and** removed its duplicate `skills:` key.

### 5. Skill counts brought to threshold
- Every engineer now has ≥5 valid skills (`web-ui-engineer` was empty → 8; `nestjs-engineer`/`data-scientist` 3 → 8/9, language-appropriate).
- Every single-skill agent now has ≥2 valid skills (`content`, `tmux` were empty → populated).

## Verification — all 5 previously-failing tests pass locally

```
tests/test_agent_skills.py::TestAgentSkills::test_all_agent_skills_exist_in_registry PASSED
tests/test_agent_skills.py::TestSkillsCoverage::test_engineer_agents_have_sufficient_skills PASSED
tests/test_agent_skills.py::TestSkillsCoverage::test_agents_have_reasonable_skill_count PASSED
tests/test_agent_knowledge.py::TestAgentInteractions::test_engineer_handoff_includes_qa PASSED
tests/test_agent_knowledge.py::TestAgentKnowledge::test_category_agents_have_sufficient_expertise[qa-2] PASSED
```

- `invalid_refs = 0` (was 109).
- Full suite: **139 passed, 11 skipped** (skips are DeepEval/OPENAI_API_KEY-gated, unrelated), **0 failed**.

51 files changed (+149 / −172).

Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
