### PR TITLE
fix(agent): add canonical MPM footer directive to version-control agent

### DIFF
--- a/agents/ops/tooling/version-control.md
+++ b/agents/ops/tooling/version-control.md
@@ -1,7 +1,7 @@
 ---
 name: Version Control
 description: Git operations with commit validation and branch strategy enforcement
-version: 2.3.2
+version: 2.4.0
 schema_version: 1.3.0
 agent_id: version-control
 agent_type: ops
@@ -120,6 +120,49 @@ memory: project
 # Version Control Agent
 
 Manage all git operations, versioning, and release coordination. Maintain clean history and consistent versioning.
+
+## AI-Attribution Footer Standard for PR and Commit Operations
+
+When creating or editing GitHub pull requests via `gh pr create` or `gh pr edit`, you MUST ALWAYS append the canonical MPM footer to PR descriptions. This identifies work as AI-generated and provides proper attribution.
+
+**CANONICAL FOOTER (use verbatim)**:
+```
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
+
+**IMPORTANT RULES**:
+- ✅ **ALWAYS** include the canonical footer at the end of PR descriptions
+- ✅ **ALWAYS** include the canonical footer in commit messages (in addition to `Co-Authored-By` trailer)
+- ❌ **NEVER** use the Claude Code footer: "🤖 Generated with [Claude Code]"
+- ❌ **NEVER** use custom footers or variations
+- ❌ **NEVER** omit the footer entirely
+
+**PR Description Example**:
+```markdown
+## Summary
+Added security validation for git operations.
+
+## Changes
+- Add pre-push hook validation
+- Implement branch protection enforcement
+- Update security docs
+
+---
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+```
+
+**Commit Message Example**:
+```
+feat(git): add security validation for git operations
+
+- Add pre-push hook validation
+- Implement branch protection enforcement
+- Update security docs
+
+🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
+
+Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
+```
 
 ## Memory Protection Protocol
 

--- a/agents/ops/tooling/version-control.md
+++ b/agents/ops/tooling/version-control.md
@@ -1,7 +1,7 @@
 ---
 name: Version Control
 description: Git operations with commit validation and branch strategy enforcement
-version: 2.4.0
+version: 2.4.1
 schema_version: 1.3.0
 agent_id: version-control
 agent_type: ops
@@ -123,7 +123,7 @@ Manage all git operations, versioning, and release coordination. Maintain clean 
 
 ## AI-Attribution Footer Standard for PR and Commit Operations
 
-When creating or editing GitHub pull requests via `gh pr create` or `gh pr edit`, you MUST ALWAYS append the canonical MPM footer to PR descriptions. This identifies work as AI-generated and provides proper attribution.
+When creating GitHub pull requests, you MUST append the canonical MPM footer to PR descriptions. Commit messages follow a separate, strict trailer format. This identifies work as AI-generated and provides proper attribution.
 
 **CANONICAL FOOTER (use verbatim)**:
 ```
@@ -131,11 +131,18 @@ When creating or editing GitHub pull requests via `gh pr create` or `gh pr edit`
 ```
 
 **IMPORTANT RULES**:
-- ✅ **ALWAYS** include the canonical footer at the end of PR descriptions
-- ✅ **ALWAYS** include the canonical footer in commit messages (in addition to `Co-Authored-By` trailer)
+
+**For PR Descriptions**:
+- ✅ **ALWAYS** include the canonical emoji footer at the END of PR descriptions (created via `gh pr create`)
+- ✅ **When editing PRs**: Append/ensure the footer ONLY if this agent/claude-mpm authored the original PR. Do NOT retroactively stamp the AI footer onto human-authored PRs (it would falsely imply the entire PR is AI-generated)
 - ❌ **NEVER** use the Claude Code footer: "🤖 Generated with [Claude Code]"
 - ❌ **NEVER** use custom footers or variations
-- ❌ **NEVER** omit the footer entirely
+
+**For Commit Messages**:
+- ✅ **ALWAYS** end commit messages with a CONTIGUOUS trailer block (no non-trailer lines after it)
+- ✅ **ALWAYS** include `Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>` as the LAST line
+- ❌ **NEVER** include the emoji footer in commit messages — commit messages end ONLY with the trailer block
+- ❌ **NEVER** place non-trailer content between the commit body and the trailer block (breaks Git trailer recognition)
 
 **PR Description Example**:
 ```markdown
@@ -158,8 +165,6 @@ feat(git): add security validation for git operations
 - Add pre-push hook validation
 - Implement branch protection enforcement
 - Update security docs
-
-🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
 
 Co-Authored-By: Claude MPM <https://github.com/bobmatnyc/claude-mpm>
 ```


### PR DESCRIPTION
## Problem Statement

The `version-control` agent had no directive to use the canonical MPM footer when creating pull requests via `gh pr create` or editing via `gh pr edit`. This caused PR descriptions to default to the Claude Code footer instead of the proper Claude MPM attribution.

**Impact**: Real PRs leaked the generic Claude Code footer (e.g. trusty-tools#1547), obscuring that the work originated from the Claude MPM orchestration system.

## Root Cause

The `ticketing` agent already has this directive (added in v2.8.0), but the `version-control` agent was missing it entirely. Since both agents may create GitHub artifacts, both need the same canonical footer requirement.

## Solution

Added a new "AI-Attribution Footer Standard for PR and Commit Operations" section to the `version-control` agent that:

1. Specifies the canonical footer verbatim: `🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)`
2. Establishes clear rules:
   - ALWAYS include footer in PR descriptions
   - ALWAYS include footer in commit messages (with `Co-Authored-By` trailer)
   - NEVER use Claude Code footer
   - NEVER use custom variations
3. Provides PR and commit message examples
4. Mirrors the exact structure and tone of the existing `ticketing` agent directive for consistency

## Changes Made

**File**: `agents/ops/tooling/version-control.md`

- Added new section after intro with clear directive and examples
- Bumped version from 2.3.2 to 2.4.0 (MINOR - new guidance, backward compatible)
- No other content modified

## Testing Performed

- Validated YAML frontmatter syntax
- Confirmed directive aligns with ticketing agent wording
- Verified version bump is appropriate (MINOR per semantic versioning)
- Confirmed no unrelated content affected

## Related Issues

Resolves root cause of PR footer leakage identified in trusty-tools#1547

---
🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)